### PR TITLE
修复用户管理中查询未指定角色的用户时间出现的 无法绑定由多个部分组成的标识符

### DIFF
--- a/Libraries/Sdk/Xms.Sdk/Data/QueryExpressionResolver.cs
+++ b/Libraries/Sdk/Xms.Sdk/Data/QueryExpressionResolver.cs
@@ -517,8 +517,20 @@ namespace Xms.Sdk.Data
         private string MakeCondition(Schema.Domain.Entity entityMetaData, string entityAliaName, ConditionExpression conditionNode)
         {
             string condition = string.Empty;
-            string attrName = (conditionNode.AttributeName.IndexOf('.') < 0 ? PocoHelper.WrapName(entityAliaName) + "." : "") + PocoHelper.WrapName(conditionNode.AttributeName);
-            //var attrMeta = AttributeList.Exists(n => n.Name.IsCaseInsensitiveEqual(attrName) && n.EntityName.IsCaseInsensitiveEqual(entityMetaData.Name));
+           // string attrName = (conditionNode.AttributeName.IndexOf('.') < 0 ? PocoHelper.WrapName(entityAliaName) + "." : "") + PocoHelper.WrapName(conditionNode.AttributeName);
+           
+            //下方为修改后的代码
+             string  attrName = string.Empty;
+
+           if (conditionNode.AttributeName.IndexOf('.') < 0)
+            {
+               attrName = PocoHelper.WrapName(entityAliaName) + "." + PocoHelper.WrapName(conditionNode.AttributeName);
+             }
+            else {
+                attrName = conditionNode.AttributeName;
+           }
+           
+           //var attrMeta = AttributeList.Exists(n => n.Name.IsCaseInsensitiveEqual(attrName) && n.EntityName.IsCaseInsensitiveEqual(entityMetaData.Name));
             string value = (conditionNode.Values != null) ? string.Join(",", conditionNode.Values).TrimSafe() : string.Empty;
             string parameter = "@" + Parameters.Args.Count;
 


### PR DESCRIPTION
修复用户管理查询  查询 查询未指定角色的用户
  string 无法绑定由多个部分组成的标识符 "[lk_SystemUserRoles_SystemUserId.systemuserid] IS NULL AND [systemuser.statecode"。: SELECT  COUNT(*) FROM [systemuserView] AS [systemuser] WITH(NOLOCK) LEFT JOIN [systemuserrolesView] AS [lk_SystemUserRoles_SystemUserId] WITH(NOLOCK) ON [lk_SystemUserRoles_SystemUserId].[systemuserid] = [systemuser].[systemuserid]  WHERE  ( [[lk_SystemUserRoles_SystemUserId].[systemuserid]] IS NULL AND [systemuser].[statecode]=@0 )   ;